### PR TITLE
Fix kube-docker image tag

### DIFF
--- a/services/kube-docker/start-kubernetes.sh
+++ b/services/kube-docker/start-kubernetes.sh
@@ -7,7 +7,7 @@ docker run -d \
     --net=host \
     --pid=host \
     --privileged \
-    gcr.io/google_containers/hyperkube-${ARCH}:${K8S_VERSION} \
+    gcr.io/google_containers/hyperkube-${ARCH}:v${K8S_VERSION} \
     /hyperkube kubelet \
         --containerized \
         --hostname-override=127.0.0.1 \


### PR DESCRIPTION
Looking at [the registry](https://console.cloud.google.com/gcr/images/google-containers/global/hyperkube-amd64?project=google-containers), it looks like you made a typo.